### PR TITLE
Use buffer size of 7 so that (len + buffer) fit in sizeof(char*).

### DIFF
--- a/examples/basic/main.cpp
+++ b/examples/basic/main.cpp
@@ -1,6 +1,8 @@
 #include "idstring.h"
 
 int main(int argc, char **argv) {
+    assert(sizeof(istr_dptr_t) == sizeof(char*));  // The promise
+
     istr_t strings[64];
     ISTR_DELIMITER = '/';
 

--- a/idstring.h
+++ b/idstring.h
@@ -26,7 +26,7 @@
 // Pointer which allows storing small strings directly inside the
 // pointer.
 
-#define ISTR_DPTR_INTERNAL_MAXLEN (sizeof(char*))
+#define ISTR_DPTR_INTERNAL_MAXLEN (sizeof(char*) - sizeof(uint8_t))
 #define ISTR_DPTR_MASK 0b111
 
 //#if INTPTR_MAX == 4294967295


### PR DESCRIPTION
Previously, the union actually used twice, 16 bytes: 9 + padding.

(This of course means, that we can only store strings with len
7 instead of 8)

Signed-off-by: Henner Zeller <h.zeller@acm.org>